### PR TITLE
Do not nest the build output

### DIFF
--- a/OpenCVApp/src/Makefile
+++ b/OpenCVApp/src/Makefile
@@ -50,7 +50,7 @@ include $(TOP)/configure/RULES
 
 ifdef T_A
 install:
-	$(CMAKE) $(OPENCV_SRC) -G "$(CMAKE_GENERATOR)" -A "$(PLATFORM)" -DCMAKE_INSTALL_PREFIX:PATH="$(OPENCV_INSTALL)" $(CMAKE_CONFIG_FLAGS)
+	$(CMAKE) $(OPENCV_SRC) -G "$(CMAKE_GENERATOR)" -A "$(PLATFORM)" -DOpenCV_INSTALL_BINARIES_PREFIX="" -DCMAKE_INSTALL_PREFIX:PATH="$(OPENCV_INSTALL)" $(CMAKE_CONFIG_FLAGS)
 	$(CMAKE) --build . --target install --config $(CMAKE_CONFIG) $(CMAKE_BUILD_FLAGS)
 	-$(MKDIR) $(TOP)/bin
 	-$(MKDIR) $(TOP)/bin/$(EPICS_HOST_ARCH)
@@ -59,11 +59,11 @@ install:
 	$(CMAKE) -E remove_directory $(TOP)/include
 	$(CMAKE) -E copy_directory $(OPENCV_INSTALL)/include $(TOP)/include
 ifeq ($(findstring linux,$(EPICS_HOST_ARCH)),)
-	$(CP) -f $(OPENCV_INSTALL)/*/*/bin/*.exe $(TOP)/bin/$(EPICS_HOST_ARCH)/
-	$(CP) -f $(OPENCV_INSTALL)/*/*/bin/*.dll $(TOP)/bin/$(EPICS_HOST_ARCH)/
-	$(CP) -f $(OPENCV_INSTALL)/*/*/$(WININSTLIB)/*.lib $(TOP)/lib/$(EPICS_HOST_ARCH)/
-	$(CP) -f $(OPENCV_INSTALL)/*/*/$(WININSTLIB)/opencv_core*.lib $(TOP)/lib/$(EPICS_HOST_ARCH)/opencv_core.lib
-	$(CP) -f $(OPENCV_INSTALL)/*/*/$(WININSTLIB)/opencv_imgproc*.lib $(TOP)/lib/$(EPICS_HOST_ARCH)/opencv_imgproc.lib
+	$(CP) -f $(OPENCV_INSTALL)/bin/*.exe $(TOP)/bin/$(EPICS_HOST_ARCH)/
+	$(CP) -f $(OPENCV_INSTALL)/bin/*.dll $(TOP)/bin/$(EPICS_HOST_ARCH)/
+	$(CP) -f $(OPENCV_INSTALL)/$(WININSTLIB)/*.lib $(TOP)/lib/$(EPICS_HOST_ARCH)/
+	$(CP) -f $(OPENCV_INSTALL)/$(WININSTLIB)/opencv_core*.lib $(TOP)/lib/$(EPICS_HOST_ARCH)/opencv_core.lib
+	$(CP) -f $(OPENCV_INSTALL)/$(WININSTLIB)/opencv_imgproc*.lib $(TOP)/lib/$(EPICS_HOST_ARCH)/opencv_imgproc.lib
 else
 	$(CP) -f $(OPENCV_INSTALL)/lib*/libopencv* $(TOP)/lib/$(EPICS_HOST_ARCH)/
 endif


### PR DESCRIPTION
Part of ISISComputingGroup/IBEX#5173

When compiling with Visual Studio < 2019, CMake used to nest the build output under `x64/vc15/`. This does not happen anymore in VS 2019, so the build output was not being copied to the final directory.

This fix disables nesting for all versions and updates the paths to the built files accordingly.